### PR TITLE
Add notebook title specificity for comparisons

### DIFF
--- a/notebooks/cytotable_and_pycytominer_analysis.ipynb
+++ b/notebooks/cytotable_and_pycytominer_analysis.ipynb
@@ -5,9 +5,9 @@
    "id": "9cef710a-ff78-4598-bf7b-2b9b75448c32",
    "metadata": {},
    "source": [
-    "# CytoTable and Pycytominer Performance Comparisons\n",
+    "# CytoTable (convert) and Pycytominer (SingleCells.merge_single_cells) Performance Comparisons\n",
     "\n",
-    "This notebook explores CytoTable and Pycytominer usage with datasets of varying size to help describe performance impacts."
+    "This notebook explores CytoTable (convert) and Pycytominer (SingleCells.merge_single_cells) usage with datasets of varying size to help describe performance impacts."
    ]
   },
   {

--- a/notebooks/cytotable_and_pycytominer_analysis.py
+++ b/notebooks/cytotable_and_pycytominer_analysis.py
@@ -13,9 +13,9 @@
 #     name: ipyflow
 # ---
 
-# # CytoTable and Pycytominer Performance Comparisons
+# # CytoTable (convert) and Pycytominer (SingleCells.merge_single_cells) Performance Comparisons
 #
-# This notebook explores CytoTable and Pycytominer usage with datasets of varying size to help describe performance impacts.
+# This notebook explores CytoTable (convert) and Pycytominer (SingleCells.merge_single_cells) usage with datasets of varying size to help describe performance impacts.
 
 # set ipyflow reactive mode
 # %flow mode reactive


### PR DESCRIPTION
This PR adds a change mentioned by @gwaybio  https://github.com/cytomining/CytoTable-benchmarks/pull/6#pullrequestreview-1695253194 about specifying the comparisons as only related between CytoTable and Pyctominer (SingleCells.merge_single_cells). I meant to add this but forgot to before merging #6.