### PR TITLE
Add DOI to readme and `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,6 +35,10 @@ keywords:
   - pycytominer
   - benchmarking
 license: BSD-3-Clause
+identifiers:
+  - description: Software DOI
+    type: doi
+    value: "10.5281/zenodo.15425830"
 references:
   - type: software
     title: CytoTable

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🛠️ CytoTable benchmarks
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15425830.svg)](https://doi.org/10.5281/zenodo.15425830)
+
 A repository for analyzing various benchmarks related to [CytoTable](https://github.com/cytomining/CytoTable).
 
 ## Installation


### PR DESCRIPTION
This PR adds the Zenodo DOI to the readme and `CITATION.cff` to make it easy to find and reference.